### PR TITLE
fix `$(...).nestable is not a function` bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   ],
   "dependencies": {
-    "jquery": "^1.7.2"
+    "jquery": ">=1.7.2"
   },
   "devDependencies": {
     "gulp": "^3.9.1",


### PR DESCRIPTION
When other package uses  `jquery 2.*`,  the `webpack` packs both ` jquery 2.*` and `jquery 1.7.2`, then happen`$(...).nestable is not a function` error   
so change `package.json` jquery dependency